### PR TITLE
Fix security

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3806,7 +3806,7 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.1.11",
+            "version": "2.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",

--- a/composer.lock
+++ b/composer.lock
@@ -901,7 +901,7 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",

--- a/composer.lock
+++ b/composer.lock
@@ -693,7 +693,7 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.0",
+            "version": "7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
@@ -797,7 +797,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.3"
             },
             "funding": [
                 {


### PR DESCRIPTION
This provides security updates, by updating `composer.lock` dependencies:

 - `"composer/composer": "2.2.12"`
 - `"guzzlehttp/guzzle": "7.4.3"`
 - `"guzzlehttp/psr7": "2.1.1"`