### PR TITLE
BEdita Core and API ^5.21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']
+      codecov:
+        patterns: ['codecov/*']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1"]'
+      php_versions: '["7.4", "8.0", "8.1", "8.2"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1"]'
+      php_versions: '["7.4", "8.0", "8.1", "8.2"]'
 
   unit:
     name: 'Run unit tests'
@@ -36,6 +36,7 @@ jobs:
         include:
           - php: '8.0'
           - php: '8.1'
+          - php: '8.2'
     env:
       PHP_VERSION: '${{ matrix.php }}'
 

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     },
 
     "require-dev": {
-        "cakephp/bake": "^2.8",
-        "cakephp/debug_kit": "^4.9.3",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
-        "cakephp/repl": "^0.1",
-        "phpunit/phpunit": "^9.5",
         "bedita/dev-tools": "^2.1.4",
+        "cakephp/bake": "^2.8",
+        "cakephp/cakephp-codesniffer": "~4.7.0",
+        "cakephp/debug_kit": "^4.9.3",
+        "cakephp/repl": "^0.1",
+        "dereuromark/cakephp-ide-helper": "^1.18",
         "josegonzalez/dotenv": "^3.2",
         "phpstan/phpstan": "^1.9.14",
-        "dereuromark/cakephp-ide-helper": "^1.18"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "bedita/api": "^5.14",
+        "bedita/api": "^5.21",
         "bedita/aws": "^3.0.4",
-        "bedita/core": "^5.14",
+        "bedita/core": "^5.21",
         "cakephp/cakephp": "^4.4.10",
         "cakephp/plugin-installer": "^1.3.1"
     },

--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use BEdita\API\Error\ExceptionRenderer;
+use BEdita\Core\Search\Adapter\SimpleAdapter;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
@@ -472,6 +473,18 @@ return [
                 'className' => 'BEdita/Core.Async',
                 // 'baseGenerator' => 'default',
                 'url' => env('THUMBNAILS_ASYNC_URL', null),
+            ],
+        ],
+    ],
+
+    /*
+     * Search engine configuration.
+     */
+    'Search' => [
+        'use' => 'default',
+        'adapters' => [
+            'default' => [
+                'className' => SimpleAdapter::class,
             ],
         ],
     ],

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -232,4 +232,16 @@ return [
     //     // default lang tag - may be null
     //     'default' => null,
     // ],
+
+    /*
+     * Search engine configuration.
+     */
+    // 'Search' => [
+    //     'use' => 'default',
+    //     'adapters' => [
+    //         'default' => [
+    //             'className' => SimpleAdapter::class,
+    //         ],
+    //     ],
+    // ],
 ];


### PR DESCRIPTION
This bumps BEdita Core and API to version ^5.21 (and `cakephp-codesniffer` to ^4.7).

This introduces default `Search` configuration in `config/app.php`.

This also adds `dependabot.yml` to github configuration.