### PR TITLE
BEdita API and Core 5.29, Cakephp 4.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1", "8.2"]'
+      php_versions: '["8.1", "8.2", "8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1", "8.2"]'
+      php_versions: '["8.1", "8.2", "8.3"]'
 
   unit:
     name: 'Run unit tests'
@@ -32,11 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
+          - '8.1'
         include:
-          - php: '8.0'
-          - php: '8.1'
           - php: '8.2'
+          - php: '8.3'
     env:
       PHP_VERSION: '${{ matrix.php }}'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,12 +14,12 @@ on:
 
 jobs:
   cs:
-    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
       php_versions: '["8.1", "8.2", "8.3"]'
 
   stan:
-    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
       php_versions: '["8.1", "8.2", "8.3"]'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,10 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.1'
-        include:
-          - php: '8.2'
-          - php: '8.3'
+          - '8.2'
+          - '8.3'
     env:
       PHP_VERSION: '${{ matrix.php }}'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   unit:
     name: 'Run unit tests'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-job:
-    uses: bedita/github-workflows/.github/workflows/release.yml@v1
+    uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'master'
       dist_branches: '["master"]'

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is the skeleton app to build BEdita5 API projects.
 
 ## Requirements
 
-1. PHP 7.4, 8.0 and 8.1
-1. Download latest [Composer](https://getcomposer.org/doc/00-intro.md) or update via `composer self-update`.
+1. PHP >= 8.1
+2. Download latest [Composer](https://getcomposer.org/doc/00-intro.md) or update via `composer self-update`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the skeleton app to build BEdita5 API projects.
 ## Requirements
 
 1. PHP >= 8.1
-2. Download latest [Composer](https://getcomposer.org/doc/00-intro.md) or update via `composer self-update`.
+1. Download latest [Composer](https://getcomposer.org/doc/00-intro.md) or update via `composer self-update`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the skeleton app to build BEdita5 API projects.
 
 ## Requirements
 
-1. PHP >= 8.1
+1. PHP >= 8.2
 1. Download latest [Composer](https://getcomposer.org/doc/00-intro.md) or update via `composer self-update`.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "bedita/api": "^5.24",
-        "bedita/aws": "^3.0.4",
-        "bedita/core": "^5.24",
+        "bedita/api": "^5.28",
+        "bedita/aws": "^3.0.5",
+        "bedita/core": "^5.28",
         "cakephp/cakephp": "^4.5.0",
         "cakephp/plugin-installer": "^1.3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://www.bedita.com",
     "license": "MIT",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "bedita/api": "^5.24",
         "bedita/aws": "^3.0.4",
         "bedita/core": "^5.24",

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "homepage": "https://www.bedita.com",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
-        "bedita/api": "^5.21",
+        "php": ">=8.1",
+        "bedita/api": "^5.24",
         "bedita/aws": "^3.0.4",
-        "bedita/core": "^5.21",
-        "cakephp/cakephp": "^4.4.10",
+        "bedita/core": "^5.24",
+        "cakephp/cakephp": "^4.5.0",
         "cakephp/plugin-installer": "^1.3.1"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "bedita/api": "^5.28",
+        "bedita/api": "^5.29",
         "bedita/aws": "^3.0.5",
-        "bedita/core": "^5.28",
+        "bedita/core": "^5.29",
         "cakephp/cakephp": "^4.5.0",
         "cakephp/plugin-installer": "^1.3.1"
     },


### PR DESCRIPTION
This updates `composer.json` dependencies to use BEdita 5.29, cakephp 4.5.
This also updates github workflow to run against php 8.2 and 8.3.