### PR TITLE
BE 5.41 and composer "migrate" script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "migrate": [
             "@cache-clear",
             "@migrations",
+            "@cache-clear",
             "@project-model",
             "@cache-clear"
         ],


### PR DESCRIPTION
This update BEdita API and Core dependencies to v5.41 and add `migrate` script in `composer.json`.